### PR TITLE
allow env vars to be passed as parameters to the orb

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -14,7 +14,7 @@ steps:
         - restore_cache:
             key: cosign-cache-<< parameters.version >>
   - run:
-      name: Install Cosign << parameters.version >>
+      name: Install Cosign
       environment:
         PARAM_VERSION: << parameters.version >>
       command: << include(scripts/install.sh) >>

--- a/src/commands/sign_image.yml
+++ b/src/commands/sign_image.yml
@@ -8,7 +8,7 @@ parameters:
     description: Base-64 encoded private key.
 steps:
   - run:
-      name: Sign image << parameters.image >>
+      name: Sign image
       environment:
         PARAM_IMAGE: << parameters.image >>
         PARAM_PRIVATE_KEY: << parameters.private_key >>

--- a/src/commands/verify_image.yml
+++ b/src/commands/verify_image.yml
@@ -8,7 +8,7 @@ parameters:
     description: Base-64 encoded public key.
 steps:
   - run:
-      name: Verify signature for << parameters.image >>
+      name: Verify signature
       environment:
         PARAM_IMAGE: << parameters.image >>
         PARAM_PUBLIC_KEY: << parameters.public_key >>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+PARAM_VERSION=$(eval echo "${PARAM_VERSION}")
+
 if [[ -f cosign.tar.gz ]]; then
     tar xzf cosign.tar.gz
 fi

--- a/src/scripts/sign_image.sh
+++ b/src/scripts/sign_image.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+PARAM_IMAGE=$(eval echo "${PARAM_IMAGE}")
+PARAM_PRIVATE_KEY=$(eval echo "${PARAM_PRIVATE_KEY}")
+
 # Load the private key, normally a base64 encoded secret within a CircleCI context
 echo "${PARAM_PRIVATE_KEY}" | base64 --decode > cosign.key
 

--- a/src/scripts/verify_image.sh
+++ b/src/scripts/verify_image.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+PARAM_IMAGE=$(eval echo "${PARAM_IMAGE}")
+PARAM_PUBLIC_KEY=$(eval echo "${PARAM_PUBLIC_KEY}")
+
 # Load public key, normally a base64 encoded secret within a CircleCI context
 echo "${PARAM_PUBLIC_KEY}" | base64 --decode > cosign.pub
 


### PR DESCRIPTION
circleci doesn't appear to expand environment variables that get passed into orbs as parameters. testing this out as a temporary workaround.