### PR TITLE
feat: add support for cosign v2 and fix command injection

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -5,7 +5,7 @@ parameters:
     default: true
   version:
     type: string
-    default: "1.13.1"
+    default: "2.2.3"
     description: Specify the semver of the Cosign version to install.
 steps:
   - when:

--- a/src/commands/sign_image.yml
+++ b/src/commands/sign_image.yml
@@ -6,10 +6,14 @@ parameters:
   private_key:
     type: string
     description: Base-64 encoded private key.
+  password:
+    type: string
+    description: Password to use the private key.
 steps:
   - run:
       name: Sign image
       environment:
         PARAM_IMAGE: << parameters.image >>
         PARAM_PRIVATE_KEY: << parameters.private_key >>
+        PARAM_PASSWORD: << parameters.password >>
       command: << include(scripts/sign_image.sh) >>

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,14 +2,36 @@
 
 set -e
 
-PARAM_VERSION=$(eval echo "${PARAM_VERSION}")
+# Use parameter expansion to ensure CircleCI environment variables can be passed in as orb parameters
+expand_env_var() {
+    if [[ "${1}" =~ ^\$\{(.*)\}$ ]] || [[ "${1}" =~ ^\$(.*)$ ]]; then
+        INNER_ENV_VAR="${BASH_REMATCH[1]}"
+        VALUE="${!INNER_ENV_VAR}"
+        if [[ -n "${VALUE}" ]]; then
+            echo "${VALUE}"
+            return 0
+        fi
+    fi
+    echo "${1}"
+}
 
+PARAM_VERSION=$(expand_env_var "${PARAM_VERSION}")
+
+# Check if the cosign tar file was in the CircleCI cache.
+# Cache restoration is handled in install.yml
 if [[ -f cosign.tar.gz ]]; then
     tar xzf cosign.tar.gz
 fi
+
+# If there was no cache hit, go ahead and re-download the binary.
+# Tar it up to save on cache space used.
 if [[ ! -f cosign-linux-amd64 ]]; then
     wget "https://github.com/sigstore/cosign/releases/download/v${PARAM_VERSION}/cosign-linux-amd64"
     tar czf cosign.tar.gz cosign-linux-amd64
 fi
+
+# A cosign binary should exist at this point, regardless of whether it was obtained
+# through cache or re-downloaded. Move it to an appropriate bin directory and mark it
+# as executable.
 sudo mv cosign-linux-amd64 /usr/local/bin/cosign
 sudo chmod +x /usr/local/bin/cosign

--- a/src/scripts/sign_image.sh
+++ b/src/scripts/sign_image.sh
@@ -1,18 +1,82 @@
 #!/bin/bash
 
+# This script is intended to sign container images the traditional way -- within a private
+# organization with a pre-generated key file. E.g., at this time it doesn't support keyless
+# signing, transparency log uploads to Rekor, or other advanced features just yet.
+
 set -e
 
-PARAM_IMAGE=$(eval echo "${PARAM_IMAGE}")
-PARAM_PRIVATE_KEY=$(eval echo "${PARAM_PRIVATE_KEY}")
+# Use parameter expansion to ensure CircleCI environment variables can be passed in as orb parameters
+expand_env_var() {
+    if [[ "${1}" =~ ^\$\{(.*)\}$ ]] || [[ "${1}" =~ ^\$(.*)$ ]]; then
+        INNER_ENV_VAR="${BASH_REMATCH[1]}"
+        VALUE="${!INNER_ENV_VAR}"
+        if [[ -n "${VALUE}" ]]; then
+            echo "${VALUE}"
+            return 0
+        fi
+    fi
+    echo "${1}"
+}
+
+PARAM_IMAGE=$(expand_env_var "${PARAM_IMAGE}")
+PARAM_PRIVATE_KEY=$(expand_env_var "${PARAM_PRIVATE_KEY}")
+PARAM_PASSWORD=$(expand_env_var "${PARAM_PASSWORD}")
+
+# Cleanup makes a best effort to destroy all secrets.
+cleanup_secrets() {
+    echo "Cleaning up secrets..."
+    shred -vzu -n 10 cosign.key 2> /dev/null || true
+    unset PARAM_PRIVATE_KEY
+    unset PARAM_PASSWORD
+    unset COSIGN_PASSWORD
+    echo "Secrets destroyed."
+}
+
+# Verify Cosign version is supported
+COSIGN_VERSION=$(cosign version --json 2>&1 | jq -r '.gitVersion' | cut -c2-)
+COSIGN_MAJOR_VERSION=$(echo "${COSIGN_VERSION}" | cut -d '.' -f 1)
+if [ "${COSIGN_MAJOR_VERSION}" != "1" ] && [ "${COSIGN_MAJOR_VERSION}" != "2" ]; then
+    echo "Unsupported Cosign version: ${MAJOR_VERSION}"
+    cleanup_secrets
+    exit 1
+fi
+echo "Detected Cosign major version: ${COSIGN_MAJOR_VERSION}"
+
+# Determine the image digest
+echo "Determining image URI digest..."
+IMAGE_URI_DIGEST=""
+if command -v crane 1> /dev/null; then
+    echo "  Tool: crane"
+    DIGEST=$(crane digest "${PARAM_IMAGE}")
+    IMAGE_WITHOUT_TAG=$(echo "${PARAM_IMAGE}" | cut -d ':' -f 1)
+    IMAGE_URI_DIGEST="${IMAGE_WITHOUT_TAG}@${DIGEST}"
+elif command -v docker 1> /dev/null; then
+    echo "  Tool: docker"
+    IMAGE_URI_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${PARAM_IMAGE}")
+else
+    echo "This orb requires that either crane or docker be installed."
+    cleanup_secrets
+    exit 1
+fi
+echo "  Image URI Digest: ${IMAGE_URI_DIGEST}"
 
 # Load the private key, normally a base64 encoded secret within a CircleCI context
+# Note that a Cosign v2 key used with Cosign v1 may throw: unsupported pem type: ENCRYPTED SIGSTORE PRIVATE KEY
 echo "${PARAM_PRIVATE_KEY}" | base64 --decode > cosign.key
+echo "Wrote private key: cosign.key"
+
+# Load the password into COSIGN_PASSWORD, preventing the "cosign sign" command from prompting
+# for a password in the CI pipeline.
+export COSIGN_PASSWORD="${PARAM_PASSWORD}"
 
 # Sign the image using its digest
-IMAGE_DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' "${PARAM_IMAGE}")
-echo "Signing ${IMAGE_DIGEST}..."
-cosign sign --key cosign.key "${IMAGE_DIGEST}"
+echo "Signing ${IMAGE_URI_DIGEST}..."
+if [ "${COSIGN_MAJOR_VERSION}" == "1" ]; then
+    cosign1 sign --key cosign.key --no-tlog-upload "${IMAGE_URI_DIGEST}"
+else
+    cosign sign --key cosign.key --tlog-upload=false "${IMAGE_URI_DIGEST}"
+fi
 
-# As an precautionary measure, destroy the private key at this point
-shred -vzu -n 10 cosign.key
-unset PARAM_PRIVATE_KEY
+# Cleanup before exiting
+cleanup_secrets

--- a/src/scripts/verify_image.sh
+++ b/src/scripts/verify_image.sh
@@ -2,14 +2,41 @@
 
 set -e
 
-PARAM_IMAGE=$(eval echo "${PARAM_IMAGE}")
-PARAM_PUBLIC_KEY=$(eval echo "${PARAM_PUBLIC_KEY}")
+# Use parameter expansion to ensure CircleCI environment variables can be passed in as orb parameters
+expand_env_var() {
+    if [[ "${1}" =~ ^\$\{(.*)\}$ ]] || [[ "${1}" =~ ^\$(.*)$ ]]; then
+        INNER_ENV_VAR="${BASH_REMATCH[1]}"
+        VALUE="${!INNER_ENV_VAR}"
+        if [[ -n "${VALUE}" ]]; then
+            echo "${VALUE}"
+            return 0
+        fi
+    fi
+    echo "${1}"
+}
+
+PARAM_IMAGE=$(expand_env_var "${PARAM_IMAGE}")
+PARAM_PUBLIC_KEY=$(expand_env_var "${PARAM_PUBLIC_KEY}")
+
+# Verify Cosign version is supported
+COSIGN_VERSION=$(cosign version --json 2>&1 | jq -r '.gitVersion' | cut -c2-)
+COSIGN_MAJOR_VERSION=$(echo "${COSIGN_VERSION}" | cut -d '.' -f 1)
+if [ "${COSIGN_MAJOR_VERSION}" != "1" ] && [ "${COSIGN_MAJOR_VERSION}" != "2" ]; then
+    echo "Unsupported Cosign version: ${MAJOR_VERSION}"
+    exit 1
+fi
+echo "Detected Cosign major version: ${COSIGN_MAJOR_VERSION}"
 
 # Load public key, normally a base64 encoded secret within a CircleCI context
 echo "${PARAM_PUBLIC_KEY}" | base64 --decode > cosign.pub
 
 # Verify image signature using the public key
 echo "Verifying cosign signature for ${PARAM_IMAGE}..."
-cosign verify --key cosign.pub "${PARAM_IMAGE}"
+if [ "${COSIGN_MAJOR_VERSION}" == "1" ]; then
+    cosign verify --key cosign.pub "${PARAM_IMAGE}"
+else
+    cosign verify --private-infrastructure=true --key cosign.pub "${PARAM_IMAGE}"
+fi
 
+# Cleanup
 rm cosign.pub


### PR DESCRIPTION
- Add support for Cosign v2 and make it the default version
- Remove potential command injection via `$(eval echo "${PARAM_VERSION}")`