### PR TITLE
fix: expand environment variables without squiggly braces

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -2,20 +2,70 @@
 
 set -e
 
-# Use parameter expansion to ensure CircleCI environment variables can be passed in as orb parameters
-expand_env_var() {
-    if [[ "${1}" =~ ^\$\{(.*)\}$ ]] || [[ "${1}" =~ ^\$(.*)$ ]]; then
-        INNER_ENV_VAR="${BASH_REMATCH[1]}"
-        VALUE="${!INNER_ENV_VAR}"
-        if [[ -n "${VALUE}" ]]; then
-            echo "${VALUE}"
-            return 0
+# Check to see if there are any environment variables within another environment
+# variable, and if so, expand them. This allows environment variables to be passed
+# as arguments to CircleCI orbs, which often don't interpret those variables correctly.
+# Although this function seems complex, it's safer than doing: VAR=$(eval echo "${VAR}")
+# and is less susceptible to command injection.
+#   - Supported: ${VARIABLE}
+#   - Unsupported: $VARIABLE
+expand_circleci_env_vars() {
+    search_substring=${1}
+    result=""
+
+    regex="([^}]*)[$]\{([a-zA-Z_]+[a-zA-Z0-9_]*)\}(.*)"
+    while [[ $search_substring =~ $regex ]]; do
+        prefix=${BASH_REMATCH[1]}
+        match=${BASH_REMATCH[2]}
+        suffix=${BASH_REMATCH[3]}
+
+        if [[ -n ${!match} ]] && [[ "${!match}" != "\${${match}}" ]]; then
+            repaired="${prefix}${!match}"
+            result="${result}${repaired}"
+            search_substring="${suffix}"
+        else
+            result="${result}${prefix}"
+            search_substring="${suffix}"
         fi
+    done
+
+    # If we're not running in aggressive mode, we can go ahead
+    # and return the result at this point
+    if [[ "${AGGRESSIVE_MODE}" != "true" ]]; then
+        echo "${result}${search_substring}"
+        return 0
     fi
-    echo "${1}"
+
+    search_substring="${result}"
+    result=""
+
+    # In aggressive mode we handle the non-squiggly brace syntax: $VARIABLE
+    # This should not be done for fields expected to contain a question mark,
+    # such as a name, description, or even a password.
+    regex="([^$]*)[$]([a-zA-Z_]+[a-zA-Z0-9_]*)(.*)"
+    while [[ $search_substring =~ $regex ]]; do
+        prefix=${BASH_REMATCH[1]}
+        match=${BASH_REMATCH[2]}
+        suffix=${BASH_REMATCH[3]}
+
+        # if the environment variable exists, evaluate it, but
+        # guard against infinite recursion. e.g., MYVAR="\$MYVAR"
+        if [[ -n ${!match} ]] && [[ "${!match}" != "\$${match}" ]]; then
+            repaired="${prefix}${!match}"
+            result="${result}${repaired}"
+            search_substring="${suffix}"
+        else
+            result="${result}${prefix}"
+            search_substring="${suffix}"
+        fi
+    done
+
+    echo "${result}${search_substring}"
+    return 0
 }
 
-PARAM_VERSION=$(expand_env_var "${PARAM_VERSION}")
+# Ensure CircleCI environment variables can be passed in as orb parameters
+PARAM_VERSION=$(expand_circleci_env_vars "${PARAM_VERSION}" true)
 
 # Check if the cosign tar file was in the CircleCI cache.
 # Cache restoration is handled in install.yml

--- a/src/scripts/verify_image.sh
+++ b/src/scripts/verify_image.sh
@@ -2,21 +2,71 @@
 
 set -e
 
-# Use parameter expansion to ensure CircleCI environment variables can be passed in as orb parameters
-expand_env_var() {
-    if [[ "${1}" =~ ^\$\{(.*)\}$ ]] || [[ "${1}" =~ ^\$(.*)$ ]]; then
-        INNER_ENV_VAR="${BASH_REMATCH[1]}"
-        VALUE="${!INNER_ENV_VAR}"
-        if [[ -n "${VALUE}" ]]; then
-            echo "${VALUE}"
-            return 0
+# Check to see if there are any environment variables within another environment
+# variable, and if so, expand them. This allows environment variables to be passed
+# as arguments to CircleCI orbs, which often don't interpret those variables correctly.
+# Although this function seems complex, it's safer than doing: VAR=$(eval echo "${VAR}")
+# and is less susceptible to command injection.
+#   - Supported: ${VARIABLE}
+#   - Unsupported: $VARIABLE
+expand_circleci_env_vars() {
+    search_substring=${1}
+    result=""
+
+    regex="([^}]*)[$]\{([a-zA-Z_]+[a-zA-Z0-9_]*)\}(.*)"
+    while [[ $search_substring =~ $regex ]]; do
+        prefix=${BASH_REMATCH[1]}
+        match=${BASH_REMATCH[2]}
+        suffix=${BASH_REMATCH[3]}
+
+        if [[ -n ${!match} ]] && [[ "${!match}" != "\${${match}}" ]]; then
+            repaired="${prefix}${!match}"
+            result="${result}${repaired}"
+            search_substring="${suffix}"
+        else
+            result="${result}${prefix}"
+            search_substring="${suffix}"
         fi
+    done
+
+    # If we're not running in aggressive mode, we can go ahead
+    # and return the result at this point
+    if [[ "${AGGRESSIVE_MODE}" != "true" ]]; then
+        echo "${result}${search_substring}"
+        return 0
     fi
-    echo "${1}"
+
+    search_substring="${result}"
+    result=""
+
+    # In aggressive mode we handle the non-squiggly brace syntax: $VARIABLE
+    # This should not be done for fields expected to contain a question mark,
+    # such as a name, description, or even a password.
+    regex="([^$]*)[$]([a-zA-Z_]+[a-zA-Z0-9_]*)(.*)"
+    while [[ $search_substring =~ $regex ]]; do
+        prefix=${BASH_REMATCH[1]}
+        match=${BASH_REMATCH[2]}
+        suffix=${BASH_REMATCH[3]}
+
+        # if the environment variable exists, evaluate it, but
+        # guard against infinite recursion. e.g., MYVAR="\$MYVAR"
+        if [[ -n ${!match} ]] && [[ "${!match}" != "\$${match}" ]]; then
+            repaired="${prefix}${!match}"
+            result="${result}${repaired}"
+            search_substring="${suffix}"
+        else
+            result="${result}${prefix}"
+            search_substring="${suffix}"
+        fi
+    done
+
+    echo "${result}${search_substring}"
+    return 0
 }
 
-PARAM_IMAGE=$(expand_env_var "${PARAM_IMAGE}")
-PARAM_PUBLIC_KEY=$(expand_env_var "${PARAM_PUBLIC_KEY}")
+# Ensure CircleCI environment variables can be passed in as orb parameters
+PARAM_IMAGE=$(expand_circleci_env_vars "${PARAM_IMAGE}" true)
+PARAM_PUBLIC_KEY=$(expand_circleci_env_vars "${PARAM_PUBLIC_KEY}" true)
 
 # Verify Cosign version is supported
 COSIGN_VERSION=$(cosign version --json 2>&1 | jq -r '.gitVersion' | cut -c2-)


### PR DESCRIPTION
copy/paste for now due to strangle issue with sourcing common files within circleci orbs