### PR TITLE
feat: add additional protection for secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This orb is primarily intended for use by private organizations at this time. No
 
 Info for security teams:
 - Required external access to allow, if running a locked down, self-hosted CircleCI pipeline on-prem:
-  - `github.com`: For download and installation of the Cosign tool.
+  - `github.com`: For download and installation of the Cosign tool using HTTPS.
 
 ## Usage
 
@@ -33,7 +33,7 @@ Use the `cosign-orb` to handle installation of Cosign within your CircleCI pipel
 version: 2.1
 
 orbs:
-  cosign: juburr/cosign-orb@0.3.3
+  cosign: juburr/cosign-orb@0.4.0
 
 parameters:
   cimg_base_version:

--- a/src/scripts/attest.sh
+++ b/src/scripts/attest.sh
@@ -12,6 +12,10 @@ COSIGN_PRIVATE_KEY=${!PARAM_PRIVATE_KEY}
 # COSIGN_PASSWORD is a special env var used by the Cosign tool, and must be exported for
 # it to be used by Cosign. Setting it here prevents the "cosign sign" command from prompting
 # for a password in the CI pipeline.
+if ! type export | grep -q 'export is a shell builtin'; then
+    echo "The export command is not a shell builtin. It is not safe to proceed."
+    exit 1
+fi
 export COSIGN_PASSWORD=${!PARAM_PASSWORD}
 
 # Cleanup makes a best effort to destroy all secrets.
@@ -85,6 +89,8 @@ echo "  Image URI Digest: ${IMAGE_URI_DIGEST}"
 # Note that a Cosign v2 key used with Cosign v1 may throw: unsupported pem type: ENCRYPTED SIGSTORE PRIVATE KEY
 echo "${COSIGN_PRIVATE_KEY}" | base64 --decode > cosign.key
 echo "Wrote private key: cosign.key"
+chmod 0400 cosign.key
+echo "Set private key permissions: 0400"
 
 # Sign the image using its digest
 echo "Signing ${IMAGE_URI_DIGEST}..."

--- a/src/scripts/verify_attestation.sh
+++ b/src/scripts/verify_attestation.sh
@@ -20,6 +20,9 @@ trap cleanup_secrets EXIT
 
 # Load public key, normally a base64 encoded secret within a CircleCI context
 echo "${COSIGN_PUBLIC_KEY}" | base64 --decode > cosign.pub
+echo "Wrote public key: cosign.pub"
+chmod 0400 cosign.pub
+echo "Set public key permissions: 0400"
 
 # Verify image signature using the public key
 echo "Verifying cosign signature for ${IMAGE}..."

--- a/src/scripts/verify_image.sh
+++ b/src/scripts/verify_image.sh
@@ -28,6 +28,9 @@ echo "Detected Cosign major version: ${COSIGN_MAJOR_VERSION}"
 
 # Load public key, normally a base64 encoded secret within a CircleCI context
 echo "${COSIGN_PUBLIC_KEY}" | base64 --decode > cosign.pub
+echo "Wrote public key: cosign.pub"
+chmod 0400 cosign.pub
+echo "Set public key permissions: 0400"
 
 # Verify image signature using the public key
 echo "Verifying cosign signature for ${IMAGE}..."


### PR DESCRIPTION
- Explicitly set all private and public key files to 0400 permissions.
- Ensure export is a shell builtin before using it.
- Update security documentation to reflect use of HTTPS for installs